### PR TITLE
Register Handlebars helper through grunt task.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ Default value: `true`
 
 Include files without DSS annotations.
 
+#### options-handlebar_helpers
+
+Type: `Object`
+Default value: `{}`
+
+An object filled with key value pairs of handlebars helpers. The key is the helber name and the value is the callback function. See the [Handlebar documentation](http://handlebarsjs.com/#helpers) for more information.
+
 ### Example initConfig
 
 ```javascript

--- a/tasks/dss.js
+++ b/tasks/dss.js
@@ -35,6 +35,11 @@ module.exports = function(grunt){
       dss.parser(key, options.parsers[key]);
     }
 
+    // Handelbars helpers
+    for( helper in options.handlebars_helpers ) {
+      handlebars.registerHelper( helper, options.handlebars_helpers[helper] );
+    }
+
     // Build Documentation
     this.files.forEach(function(f){
 


### PR DESCRIPTION
Hey there!

Love dss and the grunt task, but I wanted to have more control over the template file so I added the option to register handlebar helpers through the grunt task. So that they're available in the template file :)

Cheers,

Sebastian
