### PR TITLE
Added a few features

### DIFF
--- a/tasks/dss.js
+++ b/tasks/dss.js
@@ -36,6 +36,24 @@ module.exports = function(grunt){
       dss.parser(key, options.parsers[key]);
     }
 
+    // Extract information about the destination folders
+    var folders = [];
+    if (this.files.length > 1){
+
+      folders = this.files.map(function(f){
+
+        var title = f.dest.split("/").filter(Boolean).pop();
+        title = title.charAt(0).toUpperCase() + title.slice(1);
+
+        return {
+          dest: f.dest,
+          title: title
+        };
+
+      });
+
+    }
+
     // Build Documentation
     this.files.forEach(function(f){
 
@@ -109,6 +127,7 @@ module.exports = function(grunt){
             // Create HTML ouput
             var html = handlebars.compile(grunt.file.read(template_filepath))({
               project: grunt.file.readJSON('package.json'),
+              folders: folders,
               files: styleguide
             });
 

--- a/tasks/dss.js
+++ b/tasks/dss.js
@@ -70,6 +70,7 @@ module.exports = function(grunt){
           if (options.include_empty_files || parsed.blocks.length) {
             // Add filename
             parsed['file'] = filename;
+            parsed['filename'] = filename.split('/').pop();
 
             // Add comment block to styleguide
             styleguide.push(parsed);

--- a/tasks/dss.js
+++ b/tasks/dss.js
@@ -24,7 +24,8 @@ module.exports = function(grunt){
       template: __dirname + '/../template/',
       template_index: 'index.handlebars',
       output_index: 'index.html',
-      include_empty_files: true
+      include_empty_files: true,
+      destination: './'
     });
 
     // Output options if --verbose cl option is passed
@@ -53,7 +54,7 @@ module.exports = function(grunt){
       // Setup
       var files = src,
           template_dir = options.template,
-          output_dir = f.dest,
+          output_dir = options.destination + f.dest,
           length = files.length,
           styleguide = [];
 

--- a/tasks/dss.js
+++ b/tasks/dss.js
@@ -25,7 +25,8 @@ module.exports = function(grunt){
       template_index: 'index.handlebars',
       output_index: 'index.html',
       include_empty_files: true,
-      destination: './'
+      destination: './',
+      compiled_css: null
     });
 
     // Output options if --verbose cl option is passed
@@ -128,7 +129,8 @@ module.exports = function(grunt){
             var html = handlebars.compile(grunt.file.read(template_filepath))({
               project: grunt.file.readJSON('package.json'),
               folders: folders,
-              files: styleguide
+              files: styleguide,
+              compiled_css: options.compiled_css
             });
 
             var output_type = 'created', output = null;


### PR DESCRIPTION
I've found a few features quite helpful while working with grunt-dss. I figured I'd share them for discussion:
- Added file name without the path for templates. Useful when you want to display files as headings.
- Added option to set location of generated docs.
- Added folder information for templates. Useful for when you're creating documentation for a complicated file structure and want to link between the documentation for each folder.
- Added option to send the location of compiled CSS. This is useful if you use a preprocessor or if you use iframes to render the examples with the generated CSS.
