### PR TITLE
Allow custom handlebar helpers

### DIFF
--- a/tasks/dss.js
+++ b/tasks/dss.js
@@ -34,6 +34,11 @@ module.exports = function(grunt){
     for(key in options.parsers){
       dss.parser(key, options.parsers[key]);
     }
+    
+    // Register custom handlebar helpers.
+    for(key in options.helpers){
+      handlebars.registerHelper(key, options.helpers[key]);
+    }
 
     // Build Documentation
     this.files.forEach(function(f){


### PR DESCRIPTION
I needed the ability to introduce my own helpers. I tried doing this globally by using my own require on handlebars, however scope doesn't allow that.
