### PR TITLE
Add options for external markup and a prefix for linking assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,37 @@ Default value: `true`
 
 Include files without DSS annotations.
 
+#### options.external_markup
+
+Type: `Boolean`
+Default value: `false`
+
+Pull in block markup from an external file. Looks for a file at `{task_path}/markup/{block name}.html`, e.g. `markup/sidebar.html` for a block with `@name: sidebar`.
+
+#### options.misc_sections
+
+Type: `Array`
+Default: `[]`
+
+A list of sections to include in addition to the list of parsed blocks, such as a section on writing style or contact information. Example section: 
+
+```javascript
+misc_sections: [
+  {
+    title: 'Writing Guidelines', //section header
+    class: 'writing-guidelines', //HTML class
+    src: 'markup/sections/writing-guideslines.html' //location of HTML to pull in
+  }
+]
+````
+
+#### options.site_prefix
+
+Type: `String`
+Default: `''`
+
+An optional prefix you can prepend to the CSS/JS assets referenced in your template. Useful for deploying your style guide alongside the project it documents in different deployment environments.
+
 ### Example initConfig
 
 ```javascript


### PR DESCRIPTION
Hey all,

Thanks for your work on DSS and this task, I've found them very useful. Thought I'd share some options I added to allow blocks to use externally defined markup, since some of my blocks need lengthy example markup and I didn't want them to overtake my style source.

I also added an option for specifying a site prefix that can be prepended to asset references in the template to make deployment to different environments easier.

Zach
